### PR TITLE
Updated RunbookWorkerServerSetup and WebServiceServerSetup to use correct exe for version checking

### DIFF
--- a/DSCResources/MSFT_xSCSMARunbookWorkerServerSetup/MSFT_xSCSMARunbookWorkerServerSetup.psm1
+++ b/DSCResources/MSFT_xSCSMARunbookWorkerServerSetup/MSFT_xSCSMARunbookWorkerServerSetup.psm1
@@ -53,7 +53,7 @@ function Get-TargetResource
 
     Import-Module $PSScriptRoot\..\..\xPDT.psm1
         
-    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WebServiceSetup.exe"
+    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WorkerSetup.exe"
     $Path = ResolvePath $Path
     $Version = (Get-Item -Path $Path).VersionInfo.ProductVersion
 
@@ -173,7 +173,7 @@ function Set-TargetResource
 
     Import-Module $PSScriptRoot\..\..\xPDT.psm1
         
-    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WebServiceSetup.exe"
+    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WorkerSetup.exe"
     $Path = ResolvePath $Path
     $Version = (Get-Item -Path $Path).VersionInfo.ProductVersion
 

--- a/DSCResources/MSFT_xSCSMAWebServiceServerSetup/MSFT_xSCSMAWebServiceServerSetup.psm1
+++ b/DSCResources/MSFT_xSCSMAWebServiceServerSetup/MSFT_xSCSMAWebServiceServerSetup.psm1
@@ -78,7 +78,7 @@ function Get-TargetResource
 
     Import-Module $PSScriptRoot\..\..\xPDT.psm1
         
-    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WorkerSetup.exe"
+    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WebServiceSetup.exe"
     $Path = ResolvePath $Path
     $Version = (Get-Item -Path $Path).VersionInfo.ProductVersion
 
@@ -233,7 +233,7 @@ function Set-TargetResource
 
     Import-Module $PSScriptRoot\..\..\xPDT.psm1
         
-    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WorkerSetup.exe"
+    $Path = Join-Path -Path (Join-Path -Path $SourcePath -ChildPath $SourceFolder) -ChildPath "\SMA\WebServiceSetup.exe"
     $Path = ResolvePath $Path
     $Version = (Get-Item -Path $Path).VersionInfo.ProductVersion
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ Imports runbook(s) into an SMA instance. The Workflow name is expected to match 
 
 ### Unreleased
 
+* Fixed MSFT_xSCSMARunbookWorkerServerSetup and MSFT_xSCSMAWebServiceServerSetup using incorrect executable for version checking.
+
 ### 1.5.0.0
 
 * Added $IdentifyingNumber for TP5/RTM and small WMI improvements


### PR DESCRIPTION
This is in response to issues #16 and #15

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xscsma/17)
<!-- Reviewable:end -->
